### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Browser/Open.pm6
+++ b/lib/Browser/Open.pm6
@@ -1,4 +1,4 @@
-module Browser::Open;
+unit module Browser::Open;
 
 use NativeCall;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
