### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-load.t
+++ b/t/01-load.t
@@ -1,7 +1,5 @@
 use v6;
-
-BEGIN { @*INC.push('lib') };
-
+use lib 'lib';
 use Test;
 
 plan 1;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
