### PR TITLE
More idiomatic call

### DIFF
--- a/lib/Browser/Open.rakumod
+++ b/lib/Browser/Open.rakumod
@@ -45,7 +45,11 @@ my @known-commands =
     ['',        'open'],
 );
 
-sub open-browser(Str $url, Bool $all = False) is export
+multi sub open-browser(Str $url, Bool :$all = False) is export {
+  open-browser $url, $all
+}
+
+multi sub open-browser(Str $url, Bool $all) is export
 {
     if $*KERNEL.name eq 'win32'
     {


### PR DESCRIPTION
I kept the original API but added the more idiomatic ```raku open-browser 'https://www.google.com/', :all
``` notation